### PR TITLE
Add a path for exporting simple default material properties

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -2225,6 +2225,79 @@ def generate_materials(operator,
         
                 materials.append(material)
 
+            else:
+
+                #
+                # A minimal export of basic material properties that didn't get picked up any other way to a pbrMetallicRoughness glTF material
+                #
+                material['pbrMetallicRoughness'] = {}
+
+                pbrMetallicRoughness = material['pbrMetallicRoughness']
+
+                alpha = 1.0
+
+                for blender_texture_slot in blender_material.texture_slots:
+                    if blender_texture_slot and blender_texture_slot.texture and blender_texture_slot.texture.type == 'IMAGE' and blender_texture_slot.texture.image is not None:
+                        #
+                        # Diffuse texture
+                        #
+                        if blender_texture_slot.use_map_color_diffuse:
+                            index = get_texture_index_by_filepath(export_settings, glTF, blender_texture_slot.texture.image.filepath)
+                            if index >= 0:
+                                baseColorTexture = {
+                                    'index' : index
+                                }
+                                pbrMetallicRoughness['baseColorTexture'] = baseColorTexture
+                        #
+                        # Ambient texture
+                        #
+                        if blender_texture_slot.use_map_ambient:
+                            index = get_texture_index_by_filepath(export_settings, glTF, blender_texture_slot.texture.image.filepath)
+                            if index >= 0:
+                                ambientTexture = {
+                                    'index' : index
+                                }
+                                material['occlusionTexture'] = ambientTexture
+                        #
+                        # Emissive texture
+                        #
+                        if blender_texture_slot.use_map_emit:
+                            index = get_texture_index_by_filepath(export_settings, glTF, blender_texture_slot.texture.image.filepath)
+                            if index >= 0:
+                                emissiveTexture = {
+                                    'index' : index
+                                }
+                                material['emissiveTexture'] = emissiveTexture
+                        #
+                        # Normal texture
+                        #
+                        if blender_texture_slot.use_map_normal:
+                            index = get_texture_index_by_filepath(export_settings, glTF, blender_texture_slot.texture.image.filepath)
+                            if index >= 0:
+                                normalTexture = {
+                                    'index' : index
+                                }
+                                material['normalTexture'] = normalTexture
+
+                #
+                # Base color factor
+                #
+                baseColorFactor = [blender_material.diffuse_color[0] * blender_material.diffuse_intensity, blender_material.diffuse_color[1] * blender_material.diffuse_intensity, blender_material.diffuse_color[2] * blender_material.diffuse_intensity, alpha]
+                if baseColorFactor[0] != 1.0 or baseColorFactor[1] != 1.0 or baseColorFactor[2] != 1.0 or baseColorFactor[3] != 1.0:
+                    pbrMetallicRoughness['baseColorFactor'] = baseColorFactor
+                    alpha = baseColorFactor[3]
+
+                #
+                # Emissive factor
+                #
+                emissiveFactor = [blender_material.emit * blender_material.diffuse_color[0], blender_material.emit * blender_material.diffuse_color[1], blender_material.emit * blender_material.diffuse_color[2]]
+                if emissiveFactor[0] != 0.0 or emissiveFactor[1] != 0.0 or emissiveFactor[2] != 0.0:
+                    material['emissiveFactor'] = emissiveFactor
+
+                material['name'] = blender_material.name
+
+                materials.append(material)
+
     #
     #
 


### PR DESCRIPTION
Exports as a pbrMetallicRoughness material, but doesn’t attempt to include any metallic or roughness properties. This allows simple content like imported OBJ files to be exported directly without converting their materials over to glTF-specific nodes.

I'm not sure if this is the default behavior you want, but it's something that I found I needed and imagine others might too. My use case is pulling .obj files off of https://vr.google.com/objects, importing them into Blender where I combine models, tweak positioning, and add camera's and such before exporting the scene to glTF 2.0. The models from this particular tool are all flat shaded, low poly, and untextured with only basic diffuse color provided. Sadly the exporter as it stands now ignores the simple diffuse colors that the .mtl files provide and export without any material at all, causing everything to display as a flat white. With this PR the exporter does pick up those materials and write them out without any further manipulation on the part of the user, which is nice.

Now I'm really not very experienced with using Blender or developing plugins with it, nor do I know the scope or direction of this particular plugin. I can easily see why you may not want this functionality to be the default, at least not as presented. So I'm happy to make adjustments to help it fit the goals of the project! And forgive me if I'm a total Blender noob with silly questions about the environment in tow. :)