### PR TITLE
Disable camera export default

### DIFF
--- a/scripts/addons/io_scene_gltf2/__init__.py
+++ b/scripts/addons/io_scene_gltf2/__init__.py
@@ -141,7 +141,7 @@ class ExportGLTF2_Base():
     export_cameras = BoolProperty(
             name='Export cameras',
             description='',
-            default=True
+            default=False
     )
 
     export_camera_infinite = BoolProperty(


### PR DESCRIPTION
In my opinion typical users will not want cameras exported by default, or perhaps even realize this is happening when exporting their models.