### PR TITLE
Put experimental options behind opt-in preference.

### DIFF
--- a/scripts/addons/io_scene_gltf2/__init__.py
+++ b/scripts/addons/io_scene_gltf2/__init__.py
@@ -393,12 +393,14 @@ class ExportGLTF2_Base():
             if self.export_morph_normal:
                 col.prop(self, 'export_morph_tangent')
 
-        col = layout.box().column()
-        col.label('Experimental:', icon='RADIO')
-        col.prop(self, 'export_lights_pbr')
-        col.prop(self, 'export_lights_cmn')
-        col.prop(self, 'export_common')
-        col.prop(self, 'export_displacement')
+        addon_prefs = context.user_preferences.addons[__name__].preferences
+        if addon_prefs.experimental:
+            col = layout.box().column()
+            col.label('Experimental:', icon='RADIO')
+            col.prop(self, 'export_lights_pbr')
+            col.prop(self, 'export_lights_cmn')
+            col.prop(self, 'export_common')
+            col.prop(self, 'export_displacement')
 
 
 class ExportGLTF2_GLTF(bpy.types.Operator, ExportHelper, ExportGLTF2_Base):
@@ -429,6 +431,18 @@ def menu_func_export_gltf(self, context):
 
 def menu_func_export_glb(self, context):
     self.layout.operator(ExportGLTF2_GLB.bl_idname, text='glTF 2.0 (.glb)')
+
+
+from bpy.types import AddonPreferences
+
+class ExportGLTF2_AddonPreferences(AddonPreferences):
+    bl_idname = __name__
+
+    experimental = BoolProperty(name='Enable experimental glTF export settings', default=False)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "experimental")
 
 
 def register():


### PR DESCRIPTION
Fixes #133, hiding the _lights, _lights_pbr, _materials_cmnBlinnPhong, and _materials_displacement extensions behind an option in addon preferences..

![screen shot 2018-01-06 at 11 13 23 pm](https://user-images.githubusercontent.com/1848368/34647421-573b9b9a-f337-11e7-9511-28b4d9234ca0.png)

References: https://docs.blender.org/api/blender_python_api_2_65_3/bpy.types.AddonPreferences.html

  