### PR TITLE
generate_duplicate_mesh failure

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1571,6 +1571,9 @@ def generate_duplicate_mesh(glTF, blender_object):
     if blender_object is None:
         return -1
 
+    if 'data' not in blender_object:
+        return -1
+      
     mesh_index = get_mesh_index(glTF, blender_object.data.name)
 
     if mesh_index == -1:


### PR DESCRIPTION
The proposed fix allowed us to successfully export one of our models to glTF 2.0.  The error we were getting before the fix was:

  File "/usr/local/blender/2.78/scripts/addons/io_scene_gltf2/gltf2_generate.py", line 1574, in generate_duplicate_mesh
    mesh_index = get_mesh_index(glTF, blender_object.data.name)
AttributeError: 'dict' object has no attribute 'data'