### PR TITLE
Filter out objects correctly based on layer

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_filter.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_filter.py
@@ -43,10 +43,13 @@ def filter_apply(export_settings):
         
         if export_settings['gltf_selected'] and not blender_object.select:
             continue
+
+        if not export_settings['gltf_layers'] and not blender_object.layers[0]:
+            continue
         
         filtered_objects.append(blender_object)
         
-        if export_settings['gltf_selected']:
+        if export_settings['gltf_selected'] or not export_settings['gltf_layers']:
             current_parent = blender_object.parent
             while current_parent:
                 if current_parent not in filtered_objects and current_parent not in implicit_filtered_objects:


### PR DESCRIPTION
Objects not on layer 0 were still exported with `Export all layers` off.

This PR filters them out properly in filter_apply, thus making sure that e.g. associated meshes are also left out of the export.