### PR TITLE
Using save rather than copy to handle images that are only in memory

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_create.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_create.py
@@ -330,12 +330,12 @@ def create_image_file(context, blender_image, dst_path, file_format):
     """
 
     if file_format == blender_image.file_format:
-        # Copy source image to destination, keeping original format.
+        # Save source image to destination, keeping original format.
 
-        src_path = bpy.path.abspath(blender_image.filepath, library=blender_image.library)
-
-        if dst_path != src_path:
-            copyfile(src_path, dst_path)
+        orig_path = blender_image.filepath
+        blender_image.filepath = dst_path
+        blender_image.save()
+        blender_image.filepath = orig_path
 
     else:
         # Render a new image to destination, converting to target format.


### PR DESCRIPTION
I've found that when I import and fbx with embedded textures the texture source path is not valid despite the texture being loaded into memory. This results in an error while trying to copy the texture. As a work around I use the "save" method rather than a copy.

I've included the traceback I was seeing and attached the FBX with an embedded texture.

```
Traceback (most recent call last):
  File "/Applications/blender/blender.app/Contents/Resources/2.79/scripts/addons/io_scene_gltf2/__init__.py", line 366, in execute
    return gltf2_export.save(self, context, export_settings)
  File "/Applications/blender/blender.app/Contents/Resources/2.79/scripts/addons/io_scene_gltf2/gltf2_export.py", line 84, in save
    generate_glTF(operator, context, export_settings, glTF)
  File "/Applications/blender/blender.app/Contents/Resources/2.79/scripts/addons/io_scene_gltf2/gltf2_generate.py", line 2750, in generate_glTF
    generate_images(operator, context, export_settings, glTF)
  File "/Applications/blender/blender.app/Contents/Resources/2.79/scripts/addons/io_scene_gltf2/gltf2_generate.py", line 2036, in generate_images
    create_image_file(context, blender_image, path, file_format)
  File "/Applications/blender/blender.app/Contents/Resources/2.79/scripts/addons/io_scene_gltf2/gltf2_create.py", line 338, in create_image_file
    copyfile(src_path, dst_path)
  File "/Applications/blender/blender.app/Contents/Resources/2.79/python/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/chars/../../Pictures/wildtextures-seamless-paper-texture.jpg'
```
[lowpolyPeopleCasualMan31_lowpolyPeopleCasualMan.fbx.zip](https://github.com/KhronosGroup/glTF-Blender-Exporter/files/2066908/lowpolyPeopleCasualMan31_lowpolyPeopleCasualMan.fbx.zip)
