### PR TITLE
Fix export of meshes with material set to object.

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1466,7 +1466,7 @@ def generate_duplicate_mesh(glTF, blender_object):
     if blender_object is None:
         return -1
 
-    if 'data' not in blender_object:
+    if not hasattr(blender_object, 'data'):
         return -1
       
     mesh_index = get_mesh_index(glTF, blender_object.data.name)
@@ -1578,7 +1578,7 @@ def generate_node_instance(context,
                             break
 
                 if need_duplicate:
-                    mesh = generate_duplicate_mesh(context, glTF)
+                    mesh = generate_duplicate_mesh(glTF, blender_object)
 
                 #
 


### PR DESCRIPTION
Fixes #186.

There are two changes here.  A large cleanup/refactor in #128 had reduced the number of parameters to a function (then named `generate_dublicate_mesh` but later renamed `generate_duplicate_mesh`).  The remaining parameters were different between the declaration and the only call site, so the wrong data was being passed into the little-used function.  Later, a patch was added in #149 to protect against the function being called with invalid parameters, essentially preventing these meshes from exporting at all.

This PR fixes the call to pass the correct parameters, and corrects the sanity check to use `hasattr` since it's now looking at an instance with an attribute, not a dict.  The sanity check might even be safe to remove now with the call site fixed, but I don't think it perceptibly hurts performance to leave it in.