### PR TITLE
Fix: disabling Z-to-Y-up also disabled KHR_lights

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1611,10 +1611,10 @@ def generate_node_instance(context,
             if blender_object.type == 'LAMP':
                 light = get_light_index(glTF, blender_object.data.name)
                 if light >= 0:
-                    if export_settings['gltf_yup']:
-                        khr_lights = {'light': light}
-                        extensions = {'KHR_lights': khr_lights}
+                    khr_lights = {'light': light}
+                    extensions = {'KHR_lights': khr_lights}
 
+                    if export_settings['gltf_yup']:
                         # Add correction node for light, as default direction is different to Blender.
                         correction_node = {}
 


### PR DESCRIPTION
Encountered an issue where disabling "Z-up to Y-up" caused a "variable referenced before assignment" error. Naively fixing it exposed the issue that disabling that option also disabled the KHR_lights extension.

This fix addresses both issues by correcting a scoping error in method `generate_node_instance`.