### PR TITLE
Export font objects (text) the same way as curves

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_filter.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_filter.py
@@ -139,7 +139,7 @@ def filter_apply(export_settings):
             
             current_blender_object = blender_object
             
-            if current_blender_object.type != 'CURVE':
+            if current_blender_object.type not in ('CURVE', 'FONT'):
                 continue
             
             if current_blender_object.data == current_blender_curve:

--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1638,7 +1638,7 @@ def generate_node_instance(context,
         #
         #
 
-        if blender_object.type == 'MESH' or blender_object.type == 'CURVE':
+        if blender_object.type in ('MESH', 'CURVE', 'FONT'):
             mesh = get_mesh_index(glTF, blender_object.data.name)
 
             if mesh >= 0:


### PR DESCRIPTION
Treat `FONT` objects (called `Text` in the UI) the same way as curves so they can be exported directly (they contain a `TextCurve` which is a subclass of `Curve`)

The current workaround is to `Convert to` `Curve from Mesh/Text` before exporting.