### PR TITLE
Pull request extensions

### DIFF
--- a/scripts/addons/io_scene_gltf2/extension_exporters/__init__.py
+++ b/scripts/addons/io_scene_gltf2/extension_exporters/__init__.py
@@ -1,0 +1,23 @@
+import glob
+import imp
+import importlib
+import os.path
+
+FILES = [
+    os.path.basename(f)[:-3]
+    for f in glob.glob(os.path.dirname(__file__) + '/*.py')
+    if os.path.isfile(f)
+]
+MODULES = [f for f in FILES if not f.startswith('_')]
+
+if '_IMPORTED' not in locals():
+    _IMPORTED = True
+
+__all__ = []
+for module in MODULES:
+    module = importlib.import_module('.'+module, __name__)
+    if '_IMPORTED' in locals():
+        imp.reload(module)
+    for attr in [getattr(module, attr) for attr in dir(module)]:
+        if hasattr(attr, 'ext_meta'):
+            __all__.append(attr)

--- a/scripts/addons/io_scene_gltf2/extension_exporters/kdab_layer_extension.py
+++ b/scripts/addons/io_scene_gltf2/extension_exporters/kdab_layer_extension.py
@@ -1,0 +1,54 @@
+
+class KDABLayers:
+    ext_meta = {
+        'name': 'KDAB_Layers',
+        'isDraft': False,
+        'enable': False,
+        'url': (
+            'https://www.kdab.com'
+        ),
+    }
+
+    KDAB_layers_extension_name = 'KDAB_Layers'
+
+    def export(self, export_settings, glTF):
+        # Mark extension as being used
+        glTF['extensionsUsed'] = glTF.get('extensionsUsed', [])
+        glTF['extensionsUsed'].append(self.KDAB_layers_extension_name)
+
+        # Export per node layers
+        filtered_objects = export_settings['filtered_objects']
+
+        # Gather mapping between glTf nodes and their names
+        name_to_glTF_index_map = {value['name']: idx for idx, value in enumerate(glTF['nodes'])}
+
+        # Gather blender objects that have been positively filtered for export
+        exported_obj_pairs = [
+            (blender_obj, glTF['nodes'][name_to_glTF_index_map[blender_obj.name]])
+            for blender_obj in filtered_objects
+        ]
+
+        layer_names = []
+
+        # Add references to extension in filtered gltF nodes
+        for blender_obj, glTF_node in exported_obj_pairs:
+            if 'kdab' in blender_obj.keys() and 'layers' in blender_obj.kdab.keys():
+                node_layer_names = [layer.name for layer in blender_obj.kdab.layers]
+                if node_layer_names:
+                    # Gather any layer names not contained in the global layers array
+                    new_layer_names = [layer_name for layer_name in node_layer_names if layer_name not in layer_names]
+                    # Add any new layer to global list of layers
+                    layer_names.extend(new_layer_names)
+
+                    # Create or extend extensions set and add KDAB extension entry on node
+                    glTF_node['extensions'] = glTF_node.get('extensions', {})
+                    glTF_node['extensions'][self.KDAB_layers_extension_name] = {}
+
+                    # Reference obj layers by using index into global layers array
+                    glTF_node['extensions'][self.KDAB_layers_extension_name]['layers'] = [layer_names.index(layer_name) for layer_name in node_layer_names]
+
+
+        # Add KDAB_Layers into glTf extension object
+        glTF['extensions'] = glTF.get('extensions', {})
+        glTF['extensions'][self.KDAB_layers_extension_name] = {}
+        glTF['extensions'][self.KDAB_layers_extension_name]['layers'] = layer_names

--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1043,7 +1043,7 @@ def generate_lights(operator,
             light['spot'] = spot
 
         light['color'] = [blender_light.color[0], blender_light.color[1], blender_light.color[2]]
-        
+
         # Blender Render lamps have no real-world units, while glTF lights use candela
         # (for punctual lights) and lux (for ambient and directional lights). For lack
         # of a better conversion, use the unitless energy value here.
@@ -2804,6 +2804,13 @@ def generate_scene(glTF):
         glTF['scene'] = index
 
 
+def generate_extensions(export_settings, glTF):
+    """
+    Generates the top level extension entries
+    """
+    for ext_exporter in export_settings['gltf_extensions']:
+        ext_exporter['extension'].export(export_settings, glTF)
+
 def generate_glTF(operator,
                   context,
                   export_settings,
@@ -2876,6 +2883,14 @@ def generate_glTF(operator,
         bpy.context.window_manager.progress_update(80)
 
     bpy.context.window_manager.progress_update(80)
+
+    # Export extensions
+    if len(export_settings['gltf_extensions']) > 0:
+        profile_start()
+        generate_extensions(export_settings, glTF)
+        profile_end('extensions')
+
+    bpy.context.window_manager.progress_update(85)
 
     #
 


### PR DESCRIPTION
Hi,

Here's a proposed change to have an extension mechanism which would allow to easily add new extensions without requiring tight coupling with the core of the exporter.
The first commit is about adding that extension mechanism. 
The second one shows how such an extension can be implemented.

We actually use the layer extension on our side, we think of layers just like you would in Gimp or Photoshop. This allows us to group nodes into layer and then filter them out (think about several pass rendering algorithms, defining subsets of scene so that you can group several scenes in the same glTf file ...)

Let me know if that could be interesting to merge moving forward and if anything should be addressed.

Thanks