### PR TITLE
Check if src and dst paths using absolute paths

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_create.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_create.py
@@ -347,7 +347,7 @@ def create_image_file(context, blender_image, dst_path, file_format):
 
         src_path = bpy.path.abspath(blender_image.filepath, library=blender_image.library)
 
-        if dst_path != src_path:
+        if os.path.abspath(dst_path) != os.path.abspath(src_path):
             copyfile(src_path, dst_path)
 
     else:

--- a/scripts/addons/io_scene_gltf2/gltf2_create.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_create.py
@@ -347,6 +347,8 @@ def create_image_file(context, blender_image, dst_path, file_format):
 
         src_path = bpy.path.abspath(blender_image.filepath, library=blender_image.library)
 
+        # Check that source and destination path are not the same using os.path.abspath
+        # because bpy.path.abspath seems to not always return an absolute path
         if os.path.abspath(dst_path) != os.path.abspath(src_path):
             copyfile(src_path, dst_path)
 


### PR DESCRIPTION
In function create_image_file, when checking that src_path and dst_path are not the same, do the check using the absolute paths.
This is because even though the paths were generated using bpy.path.abspath, the paths were not (always) absolute.

Fixes: #224

> **NOTE:** We are in the progress of merging this project into
[glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO), a combined importer/exporter.
In the future this repository (glTF-Blender-Exporter) will be archived, and issues and pull
requests closed. We recommend that new issues and pull requests be opened against glTF-Blender-IO, instead.
