### PR TITLE
Add option to export actions as a single animation

### DIFF
--- a/scripts/addons/io_scene_gltf2/__init__.py
+++ b/scripts/addons/io_scene_gltf2/__init__.py
@@ -201,6 +201,12 @@ class ExportGLTF2_Base():
             default=True
     )
 
+    export_single_animation = BoolProperty(
+            name='Export single animation',
+            description='Export all actions a as a single animation',
+            default=False
+    )
+
     export_frame_range = BoolProperty(
             name='Export within playback range',
             description='',
@@ -342,11 +348,13 @@ class ExportGLTF2_Base():
         export_settings['gltf_apply'] = self.export_apply
         export_settings['gltf_animations'] = self.export_animations
         if self.export_animations:
+            export_settings['gltf_single_animation'] = self.export_single_animation
             export_settings['gltf_current_frame'] = False
             export_settings['gltf_frame_range'] = self.export_frame_range
             export_settings['gltf_move_keyframes'] = self.export_move_keyframes
             export_settings['gltf_force_sampling'] = self.export_force_sampling
         else:
+            export_settings['gltf_single_animation'] = False
             export_settings['gltf_current_frame'] = self.export_current_frame
             export_settings['gltf_frame_range'] = False
             export_settings['gltf_move_keyframes'] = False
@@ -423,6 +431,7 @@ class ExportGLTF2_Base():
         col.label('Animation:', icon='OUTLINER_DATA_POSE')
         col.prop(self, 'export_animations')
         if self.export_animations:
+            col.prop(self, 'export_single_animation')
             col.prop(self, 'export_frame_range')
             col.prop(self, 'export_frame_step')
             col.prop(self, 'export_move_keyframes')

--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -625,15 +625,18 @@ def generate_animations(operator,
 
         #
 
-        if blender_action.name not in animations:
-            animations[blender_action.name] = {
-                'name': blender_action.name,
+        action_name = blender_action.name
+        if export_settings['gltf_single_animation']:
+            action_name = 'defaultAction'
+        if action_name not in animations:
+            animations[action_name] = {
+                'name': action_name,
                 'channels': [],
                 'samplers': []
             }
 
-        channels = animations[blender_action.name]['channels']
-        samplers = animations[blender_action.name]['samplers']
+        channels = animations[action_name]['channels']
+        samplers = animations[action_name]['samplers']
 
         # Add entry to joint cache. Current action may not need skinnning,
         # but there are too many places to check for and add it later.
@@ -750,15 +753,18 @@ def generate_animations(operator,
 
         #
 
-        if blender_action.name not in animations:
-            animations[blender_action.name] = {
-                'name': blender_action.name,
+        action_name = blender_action.name
+        if export_settings['gltf_single_animation']:
+            action_name = 'defaultAction'
+        if action_name not in animations:
+            animations[action_name] = {
+                'name': action_name,
                 'channels': [],
                 'samplers': []
             }
 
-        channels = animations[blender_action.name]['channels']
-        samplers = animations[blender_action.name]['samplers']
+        channels = animations[action_name]['channels']
+        samplers = animations[action_name]['samplers']
 
         #
 


### PR DESCRIPTION
> **NOTE:** We are in the progress of merging this project into
[glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO), a combined importer/exporter.
In the future this repository (glTF-Blender-Exporter) will be archived, and issues and pull
requests closed. We recommend that new issues and pull requests be opened against glTF-Blender-IO, instead.

Submitting PR here for now as it may still be useful for old exporter.

Add option to merge all actions into a single animation when exporting.

This is useful when you have a scene with multiple animated objects, that you need to easily playback as a single animation animation when loaded from glTF.