### PR TITLE
Fix bug when exporting multiple armatures

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_filter.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_filter.py
@@ -327,7 +327,9 @@ def filter_apply(export_settings):
         for blender_object in filtered_objects:
             if blender_object.type != 'ARMATURE' or len(blender_object.pose.bones) == 0:
                 continue
+            bone_index = 0
             for blender_bone in blender_object.pose.bones:
-                group_index[blender_bone.name] = len(group_index)
+                group_index[blender_bone.name] = bone_index
+                bone_index += 1
 
     export_settings['group_index'] = group_index


### PR DESCRIPTION
Previously bone indices have been globally assigned instead of being assigned
per armature which causes out-of-bounds bone indices (joint indices) being
generated for any mesh using any armature but the first one. This change fixes
that by assigning bone indices from zero for each armature.

> **NOTE:** We are in the progress of merging this project into
[glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO), a combined importer/exporter.
In the future this repository (glTF-Blender-Exporter) will be archived, and issues and pull
requests closed. We recommend that new issues and pull requests be opened against glTF-Blender-IO, instead.

Yes, I know glTF-Blender-IO is the maintained exporter and this is legacy. However, that exporter is simply not mature enough for any non-trivial use, even if it generates glTF nodes more in line with Blender's hierarchy.

Hopefully that will improve, but currently it fails even more miserably than this one when trying to export the scene I found this bug with, in particular:

- It doesn't handle multiple armatures correctly, just like this one
- Worse, it generates empty armature nodes out of thin air and messes up the connection between meshes and armatures in a spectacular way
- It also doesn't export animations correctly, as in my case the bones stretch and scale all across the board between key frames which seems to be a potential interpolation issue

Looks like I may very well be the first person in the world trying to export a scene with more than one armature from Blender to glTF :)