### PR TITLE
Fix another bug when exporting multiple armatures

### DIFF
--- a/scripts/addons/io_scene_gltf2/gltf2_generate.py
+++ b/scripts/addons/io_scene_gltf2/gltf2_generate.py
@@ -1810,7 +1810,7 @@ def generate_nodes(operator,
             for blender_check_object in filtered_objects:
                 blender_check_armature = blender_check_object.find_armature()
 
-                if blender_check_armature is not None and blender_check_object not in children_list:
+                if blender_check_armature == blender_object and blender_check_object not in children_list:
                     children_list.append(blender_check_object)
 
             #


### PR DESCRIPTION
Just because an object has an armature it doesn't mean it's the currently
exported armature, so check for equality instead of just existence.

> **NOTE:** We are in the progress of merging this project into
[glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO), a combined importer/exporter.
In the future this repository (glTF-Blender-Exporter) will be archived, and issues and pull
requests closed. We recommend that new issues and pull requests be opened against glTF-Blender-IO, instead.
